### PR TITLE
Code audit and optimization

### DIFF
--- a/CSV_IMPORT_GUIDE.md
+++ b/CSV_IMPORT_GUIDE.md
@@ -88,9 +88,8 @@ The import system validates your data and will show errors for:
 
 Only users with the following roles can import products:
 
-- `reseller_manager`
-- `grady_staff`
-- `grady_admin`
+- `store_manager`
+- `admin`
 
 ## Error Handling
 

--- a/INVITATION_SYSTEM.md
+++ b/INVITATION_SYSTEM.md
@@ -43,7 +43,7 @@ role.
 The system will:
 
 - Validate the invitation data
-- Check permissions (only reseller_manager+ can invite)
+- Check permissions (only store_manager or admin can invite)
 - Check for existing memberships
 - Create an invitation record
 - Generate an invitation URL
@@ -147,7 +147,7 @@ CREATE TABLE environment_invites (
 ### Common Issues
 
 1. **"You do not have permission to invite members"**
-   - Ensure the user has reseller_manager, grady_staff, or grady_admin role
+   - Ensure the user has store_manager or admin role
 
 2. **"This user is already a member"**
    - Check if the email is already associated with a user in the environment

--- a/README.md
+++ b/README.md
@@ -146,10 +146,8 @@ Categories use kebab-case IDs (e.g., `mobile-phones-main`, `laptops-main`). See
 
 ### Roles
 
-- `grady_admin` - Full system access
-- `grady_staff` - System-wide staff access
-- `reseller_manager` - Environment manager
-- `reseller_staff` - Environment staff
+- `admin` - Full system access (system-wide)
+- `store_manager` - Environment/store manager
 
 ### Product Statuses
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -39,7 +39,7 @@ This will create a user with the following credentials:
 
 - **Email**: admin@grady.app
 - **Password**: 7ftGiMiy.
-- **Role**: grady_admin (system-wide admin)
+- **Role**: admin (system-wide admin)
 
 ## Admin Capabilities
 

--- a/scripts/create-admin-user.js
+++ b/scripts/create-admin-user.js
@@ -27,7 +27,7 @@ async function createAdminUser() {
         first_name: 'Grady',
         last_name: 'Master Admin',
         company_name: 'Grady ReSellOps',
-        role: 'grady_admin'
+        role: 'admin'
       }
     })
 
@@ -60,7 +60,7 @@ async function createAdminUser() {
       .from('memberships')
       .insert({
         user_id: authData.user.id,
-        role: 'grady_admin',
+        role: 'admin',
         environment_id: null // null for system-wide admin access
       })
       .select()
@@ -75,7 +75,7 @@ async function createAdminUser() {
     console.log('🎉 Master Admin User Created Successfully!')
     console.log('Email: admin@grady.app')
     console.log('Password: 7ftGiMiy.')
-    console.log('Role: grady_admin')
+    console.log('Role: admin')
     console.log('')
     console.log('This user can:')
     console.log('- Create new environments (stores)')

--- a/scripts/verify-admin-setup.js
+++ b/scripts/verify-admin-setup.js
@@ -84,7 +84,7 @@ async function verifyAdminSetup() {
         .from('memberships')
         .insert({
           user_id: adminUser.id,
-          role: 'grady_admin',
+          role: 'admin',
           environment_id: null // null for system-wide admin access
         })
         .select()
@@ -118,7 +118,7 @@ async function verifyAdminSetup() {
     console.log('\n📋 Admin User Details:')
     console.log('   Email: admin@grady.app')
     console.log('   Password: 7ftGiMiy.')
-    console.log('   Role: grady_admin')
+    console.log('   Role: admin')
     console.log('   Access: System-wide admin')
     console.log('\n🔗 Access URLs:')
     console.log('   Login: http://localhost:3000/login')

--- a/src/app/(dashboard)/[env]/members/page.tsx
+++ b/src/app/(dashboard)/[env]/members/page.tsx
@@ -45,7 +45,7 @@ async function MembersContent({ environmentSlug }: { environmentSlug: string }) 
   }
 
   // Check if user can invite members
-  const canInvite = ['reseller_manager', 'grady_staff', 'grady_admin'].includes(membership.role)
+  const canInvite = ['store_manager', 'admin'].includes(membership.role)
 
   // Fetch members and invites
   const [members, invites] = await Promise.all([

--- a/src/app/(dashboard)/[env]/products/page.tsx
+++ b/src/app/(dashboard)/[env]/products/page.tsx
@@ -45,7 +45,7 @@ async function ProductsContent({ environmentSlug }: { environmentSlug: string })
   }
 
   // Check if user can manage products
-  const canManageProducts = ['reseller_manager', 'grady_staff', 'grady_admin'].includes(membership.role)
+  const canManageProducts = ['store_manager', 'admin'].includes(membership.role)
 
   // Fetch products, locations, and environments for the environment
   const [products, locations, environments] = await Promise.all([

--- a/src/app/(dashboard)/demo/members/page.tsx
+++ b/src/app/(dashboard)/demo/members/page.tsx
@@ -5,7 +5,7 @@ import { MembersDataTable } from '@/components/members/members-data-table'
 const demoMembers = [
   {
     id: '1',
-    role: 'reseller_manager',
+    role: 'store_manager',
     created_at: '2024-01-15T10:00:00Z',
     profiles: {
       id: '1',
@@ -16,7 +16,7 @@ const demoMembers = [
   },
   {
     id: '2',
-    role: 'reseller_staff',
+    role: 'store_manager',
     created_at: '2024-01-20T14:30:00Z',
     profiles: {
       id: '2',
@@ -31,7 +31,7 @@ const demoInvites = [
   {
     id: '1',
     email: 'newmember@demo.com',
-    role: 'reseller_staff',
+    role: 'store_manager',
     created_at: '2024-01-25T09:00:00Z',
     expires_at: '2024-02-01T09:00:00Z',
     environments: {

--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -71,7 +71,7 @@ export default async function AdminLayout({
             </Breadcrumb>
             <Badge variant="secondary" className="ml-2 flex items-center gap-1">
               <Shield className="h-3 w-3" />
-              {adminStatus.role === 'grady_admin' ? 'Master Admin' : 'Staff Admin'}
+              Admin
             </Badge>
           </div>
         </header>

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -93,7 +93,7 @@ export default async function AdminDashboardPage() {
         <div className="flex items-center space-x-2">
           <Badge variant="secondary" className="flex items-center gap-1">
             <Shield className="h-3 w-3" />
-            {adminStatus.role === 'grady_admin' ? 'Master Admin' : 'Staff Admin'}
+            Admin
           </Badge>
         </div>
       </div>

--- a/src/components/members/invite-member-dialog.tsx
+++ b/src/components/members/invite-member-dialog.tsx
@@ -48,7 +48,7 @@ export function InviteMemberDialog({
 }: InviteMemberDialogProps) {
   const [open, setOpen] = useState(false)
   const [email, setEmail] = useState('')
-  const [role, setRole] = useState('reseller_manager')
+  const [role, setRole] = useState('store_manager')
   const [inviteType, setInviteType] = useState<'environment' | 'system_admin'>('environment')
   const [targetEnvironmentId, setTargetEnvironmentId] = useState(environmentId)
   const [isLoading, setIsLoading] = useState(false)
@@ -110,7 +110,7 @@ export function InviteMemberDialog({
       }
 
       setEmail('')
-      setRole('reseller_manager')
+      setRole('store_manager')
       setInviteType('environment')
       setTargetEnvironmentId(environmentId)
       setOpen(false)
@@ -129,16 +129,11 @@ export function InviteMemberDialog({
   const getRoleOptions = () => {
     if (inviteType === 'system_admin') {
       return [
-        { value: 'grady_admin', label: 'Grady Admin' },
-        { value: 'grady_staff', label: 'Grady Staff' }
+        { value: 'admin', label: 'Admin' }
       ]
     }
-    
     return [
-      { value: 'reseller_staff', label: 'Reseller Staff' },
-      { value: 'reseller_manager', label: 'Reseller Manager' },
-      { value: 'grady_staff', label: 'Grady Staff' },
-      { value: 'grady_admin', label: 'Grady Admin' }
+      { value: 'store_manager', label: 'Store Manager' }
     ]
   }
 
@@ -182,9 +177,9 @@ export function InviteMemberDialog({
                   onValueChange={(value: 'environment' | 'system_admin') => {
                     setInviteType(value)
                     if (value === 'environment') {
-                      setRole('reseller_manager')
+                      setRole('store_manager')
                     } else {
-                      setRole('grady_admin')
+                      setRole('admin')
                     }
                   }}
                 >

--- a/src/components/members/members-data-table.tsx
+++ b/src/components/members/members-data-table.tsx
@@ -39,11 +39,9 @@ interface MembersDataTableProps {
 
 const getRoleBadge = (role: string) => {
   const roleColors = {
-    grady_admin: 'bg-red-100 text-red-800',
-    grady_staff: 'bg-orange-100 text-orange-800',
-    reseller_manager: 'bg-blue-100 text-blue-800',
-    reseller_staff: 'bg-gray-100 text-gray-800',
-  }
+    admin: 'bg-red-100 text-red-800',
+    store_manager: 'bg-blue-100 text-blue-800',
+  } as const
   
   return (
     <Badge className={roleColors[role as keyof typeof roleColors] || 'bg-gray-100 text-gray-800'}>

--- a/src/components/members/members-table.tsx
+++ b/src/components/members/members-table.tsx
@@ -47,11 +47,9 @@ interface MembersTableProps {
 export function MembersTable({ members, invites }: MembersTableProps) {
   const getRoleBadge = (role: string) => {
     const roleColors = {
-      grady_admin: 'bg-red-100 text-red-800',
-      grady_staff: 'bg-orange-100 text-orange-800',
-      reseller_manager: 'bg-blue-100 text-blue-800',
-      reseller_staff: 'bg-gray-100 text-gray-800',
-    }
+      admin: 'bg-red-100 text-red-800',
+      store_manager: 'bg-blue-100 text-blue-800',
+    } as const
     
     return (
       <Badge className={roleColors[role as keyof typeof roleColors] || 'bg-gray-100 text-gray-800'}>

--- a/src/components/nav-user.tsx
+++ b/src/components/nav-user.tsx
@@ -56,7 +56,7 @@ export function NavUser({
     process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
   )
 
-  const isAdmin = user.role === 'grady_admin' || user.role === 'grady_staff'
+  const isAdmin = user.role === 'admin'
 
   const handleLogout = async () => {
     setIsLoggingOut(true)
@@ -91,7 +91,7 @@ export function NavUser({
                   {isAdmin && (
                     <Badge variant="secondary" className="h-4 px-1 text-xs">
                       <Shield className="h-2 w-2 mr-1" />
-                      {user.role === 'grady_admin' ? 'Admin' : 'Staff'}
+                      Admin
                     </Badge>
                   )}
                 </div>
@@ -118,7 +118,7 @@ export function NavUser({
                     {isAdmin && (
                       <Badge variant="secondary" className="h-4 px-1 text-xs">
                         <Shield className="h-2 w-2 mr-1" />
-                        {user.role === 'grady_admin' ? 'Admin' : 'Staff'}
+                        Admin
                       </Badge>
                     )}
                   </div>

--- a/src/lib/db/environments/create-environment.ts
+++ b/src/lib/db/environments/create-environment.ts
@@ -77,13 +77,13 @@ export async function createEnvironment(formData: FormData) {
 
     console.log('Environment created successfully:', environment.id)
 
-    // Add the current user as a member with reseller_manager role
+    // Add the current user as a member with store_manager role
     const { error: membershipError } = await supabase
       .from('memberships')
       .insert({
         environment_id: environment.id,
         user_id: user.id,
-        role: 'reseller_manager'
+        role: 'store_manager'
       })
 
     if (membershipError) {

--- a/src/lib/db/environments/get-user-admin-status.ts
+++ b/src/lib/db/environments/get-user-admin-status.ts
@@ -19,7 +19,7 @@ export async function getUserAdminStatus(userId: string) {
       throw new Error('Failed to check admin status')
     }
 
-    const isSystemAdmin = !!systemMembership && ['grady_admin', 'grady_staff'].includes(systemMembership.role)
+    const isSystemAdmin = !!systemMembership && systemMembership.role === 'admin'
 
     return {
       isSystemAdmin,

--- a/src/lib/db/environments/invite-member.ts
+++ b/src/lib/db/environments/invite-member.ts
@@ -44,8 +44,8 @@ export async function inviteMember(formData: FormData) {
       if (!isSystemAdmin) {
         throw new Error('Only system admins can invite other system admins')
       }
-      if (role !== 'grady_admin' && role !== 'grady_staff') {
-        throw new Error('System admin invitations can only be for grady_admin or grady_staff roles')
+      if (role !== 'admin') {
+        throw new Error('System admin invitations can only be for admin role')
       }
       finalEnvironmentId = null
     } else {
@@ -57,7 +57,7 @@ export async function inviteMember(formData: FormData) {
       } else {
         // Regular user inviting to their environment
         finalEnvironmentId = environmentId
-        finalRole = 'reseller_manager' // Force manager role for environment invitations
+        finalRole = 'store_manager' // Force manager role for environment invitations
       }
 
       // Check if user has permission to invite to this environment
@@ -73,8 +73,8 @@ export async function inviteMember(formData: FormData) {
           throw new Error('You do not have permission to invite members to this environment')
         }
 
-        // Only allow reseller_manager and above to invite members
-        if (!['reseller_manager', 'grady_staff', 'grady_admin'].includes(membership.role)) {
+        // Only allow store_manager and admin to invite members
+        if (!['store_manager', 'admin'].includes(membership.role)) {
           throw new Error('You do not have permission to invite members')
         }
       }

--- a/src/lib/db/products/bulk-actions.ts
+++ b/src/lib/db/products/bulk-actions.ts
@@ -190,8 +190,8 @@ export async function bulkDeleteProducts(data: BulkActionData) {
       throw new Error('You do not have permission to delete products')
     }
 
-    // Only allow reseller_manager and above to delete products
-    if (!['reseller_manager', 'grady_staff', 'grady_admin'].includes(memberships[0].role)) {
+    // Only allow store_manager and admin to delete products
+    if (!['store_manager', 'admin'].includes(memberships[0].role)) {
       throw new Error('You do not have permission to delete products')
     }
 

--- a/src/lib/db/products/delete-product.ts
+++ b/src/lib/db/products/delete-product.ts
@@ -37,8 +37,8 @@ export async function deleteProduct(productId: string) {
       throw new Error('You do not have permission to delete this product')
     }
 
-    // Only allow reseller_manager and above to delete products
-    if (!['reseller_manager', 'grady_staff', 'grady_admin'].includes(membership.role)) {
+    // Only allow store_manager and admin to delete products
+    if (!['store_manager', 'admin'].includes(membership.role)) {
       throw new Error('You do not have permission to delete products')
     }
 

--- a/src/lib/utils/rbac.ts
+++ b/src/lib/utils/rbac.ts
@@ -2,10 +2,8 @@ import { Role, ProductStatus } from '@/types/db'
 
 // Role hierarchy (higher = more permissions)
 const roleHierarchy: Record<Role, number> = {
-  grady_admin: 4,
-  grady_staff: 3,
-  reseller_manager: 2,
-  reseller_staff: 1,
+  admin: 2,
+  store_manager: 1,
 }
 
 // Product status transition matrix
@@ -27,19 +25,19 @@ export function canTransitionStatus(fromStatus: ProductStatus, toStatus: Product
 }
 
 export function canManageProducts(userRole: Role): boolean {
-  return hasRole(userRole, 'grady_staff')
+  return hasRole(userRole, 'store_manager')
 }
 
 export function canManageUsers(userRole: Role): boolean {
-  return hasRole(userRole, 'reseller_manager')
+  return hasRole(userRole, 'store_manager')
 }
 
 export function canViewAnalytics(userRole: Role): boolean {
-  return hasRole(userRole, 'reseller_staff')
+  return hasRole(userRole, 'store_manager')
 }
 
 export function canManageEnvironments(userRole: Role): boolean {
-  return hasRole(userRole, 'grady_admin')
+  return hasRole(userRole, 'admin')
 }
 
 export function getAvailableStatusTransitions(currentStatus: ProductStatus): ProductStatus[] {

--- a/src/lib/utils/zod-schemas/environment.ts
+++ b/src/lib/utils/zod-schemas/environment.ts
@@ -18,7 +18,7 @@ export const createLocationSchema = z.object({
 export const inviteUserSchema = z.object({
   environment_id: z.string().uuid(),
   email: z.string().email('Invalid email address'),
-  role: z.enum(['grady_admin', 'grady_staff', 'reseller_manager', 'reseller_staff'] as const),
+  role: z.enum(['admin', 'store_manager'] as const),
 })
 
 export const acceptInviteSchema = z.object({

--- a/src/lib/utils/zod-schemas/invite.ts
+++ b/src/lib/utils/zod-schemas/invite.ts
@@ -2,7 +2,7 @@ import { z } from 'zod'
 
 export const inviteSchema = z.object({
   email: z.string().email('Invalid email address'),
-  role: z.enum(['grady_admin', 'grady_staff', 'reseller_manager', 'reseller_staff'] as const),
+  role: z.enum(['admin', 'store_manager'] as const),
   environment_id: z.string().uuid().nullable(),
 })
 

--- a/src/types/db.ts
+++ b/src/types/db.ts
@@ -1,4 +1,4 @@
-export type Role = 'grady_admin' | 'grady_staff' | 'reseller_manager' | 'reseller_staff'
+export type Role = 'admin' | 'store_manager'
 
 export type ProductStatus = 'taken' | 'in_repair' | 'selling' | 'sold' | 'returned' | 'discarded'
 

--- a/supabase/migrations/009_consolidate_roles.sql
+++ b/supabase/migrations/009_consolidate_roles.sql
@@ -1,0 +1,326 @@
+-- Consolidate roles to two values: 'admin' and 'store_manager'
+-- 1) Replace ROLE enum values and migrate data
+-- 2) Update constraints and RLS policies to use new roles
+
+BEGIN;
+
+-- 1) Replace ROLE enum with new values
+-- Rename old type to keep ability to cast
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM pg_type WHERE typname = 'role') THEN
+    EXECUTE 'ALTER TYPE role RENAME TO role_old';
+  END IF;
+END $$;
+
+-- Create new ROLE enum
+CREATE TYPE role AS ENUM ('admin', 'store_manager');
+
+-- memberships.role: update type and map values
+ALTER TABLE memberships ALTER COLUMN role DROP DEFAULT;
+ALTER TABLE memberships
+  ALTER COLUMN role TYPE role
+  USING (
+    CASE 
+      WHEN role::text IN ('grady_admin','grady_staff') THEN 'admin'::role
+      ELSE 'store_manager'::role
+    END
+  );
+ALTER TABLE memberships ALTER COLUMN role SET DEFAULT 'store_manager';
+
+-- environment_invites.role: update type and map values
+ALTER TABLE environment_invites
+  ALTER COLUMN role TYPE role
+  USING (
+    CASE 
+      WHEN role::text IN ('grady_admin','grady_staff') THEN 'admin'::role
+      ELSE 'store_manager'::role
+    END
+  );
+
+-- 2) Constraints: ensure only admins may have NULL environment_id
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM information_schema.table_constraints 
+    WHERE constraint_name = 'memberships_system_admin_role_check'
+  ) THEN
+    EXECUTE 'ALTER TABLE memberships DROP CONSTRAINT memberships_system_admin_role_check';
+  END IF;
+END $$;
+
+ALTER TABLE memberships
+  ADD CONSTRAINT memberships_system_admin_role_check 
+  CHECK (
+    (environment_id IS NULL AND role = 'admin') OR environment_id IS NOT NULL
+  );
+
+-- 3) Policies: drop old ones referencing legacy roles and recreate with new ones
+
+-- Profiles
+DROP POLICY IF EXISTS "Admins can view all profiles" ON profiles;
+CREATE POLICY "Admins can view all profiles" ON profiles
+  FOR SELECT USING (
+    EXISTS (
+      SELECT 1 FROM memberships m
+      WHERE m.user_id = auth.uid() AND m.role = 'admin'
+    )
+  );
+
+-- Environments
+DROP POLICY IF EXISTS "Admins can view all environments" ON environments;
+CREATE POLICY "Admins can view all environments" ON environments
+  FOR SELECT USING (
+    EXISTS (
+      SELECT 1 FROM memberships m
+      WHERE m.user_id = auth.uid() AND (
+        (m.environment_id IS NULL AND m.role = 'admin') OR
+        (m.environment_id = environments.id)
+      )
+    )
+  );
+
+DROP POLICY IF EXISTS "Admins can update any environment" ON environments;
+CREATE POLICY "Admins can update any environment" ON environments
+  FOR UPDATE USING (
+    EXISTS (
+      SELECT 1 FROM memberships m
+      WHERE m.user_id = auth.uid() AND m.role = 'admin'
+    )
+  );
+
+-- System admin global policies (from 002 migration) rewritten for 'admin'
+DROP POLICY IF EXISTS "System admins can create environments" ON environments;
+CREATE POLICY "System admins can create environments" ON environments
+  FOR INSERT WITH CHECK (
+    EXISTS (
+      SELECT 1 FROM memberships m
+      WHERE m.user_id = auth.uid() AND m.environment_id IS NULL AND m.role = 'admin'
+    )
+  );
+
+DROP POLICY IF EXISTS "System admins can update environments" ON environments;
+CREATE POLICY "System admins can update environments" ON environments
+  FOR UPDATE USING (
+    EXISTS (
+      SELECT 1 FROM memberships m
+      WHERE m.user_id = auth.uid() AND m.environment_id IS NULL AND m.role = 'admin'
+    )
+  );
+
+DROP POLICY IF EXISTS "System admins can delete environments" ON environments;
+CREATE POLICY "System admins can delete environments" ON environments
+  FOR DELETE USING (
+    EXISTS (
+      SELECT 1 FROM memberships m
+      WHERE m.user_id = auth.uid() AND m.environment_id IS NULL AND m.role = 'admin'
+    )
+  );
+
+DROP POLICY IF EXISTS "System admins can manage all memberships" ON memberships;
+CREATE POLICY "System admins can manage all memberships" ON memberships
+  FOR ALL USING (
+    EXISTS (
+      SELECT 1 FROM memberships admin_membership
+      WHERE admin_membership.user_id = auth.uid() 
+        AND admin_membership.environment_id IS NULL 
+        AND admin_membership.role = 'admin'
+    )
+  );
+
+DROP POLICY IF EXISTS "System admins can manage all products" ON products;
+CREATE POLICY "System admins can manage all products" ON products
+  FOR ALL USING (
+    EXISTS (
+      SELECT 1 FROM memberships m
+      WHERE m.user_id = auth.uid() AND m.environment_id IS NULL AND m.role = 'admin'
+    )
+  );
+
+DROP POLICY IF EXISTS "System admins can manage all locations" ON locations;
+CREATE POLICY "System admins can manage all locations" ON locations
+  FOR ALL USING (
+    EXISTS (
+      SELECT 1 FROM memberships m
+      WHERE m.user_id = auth.uid() AND m.environment_id IS NULL AND m.role = 'admin'
+    )
+  );
+
+DROP POLICY IF EXISTS "System admins can manage all invites" ON environment_invites;
+CREATE POLICY "System admins can manage all invites" ON environment_invites
+  FOR ALL USING (
+    EXISTS (
+      SELECT 1 FROM memberships m
+      WHERE m.user_id = auth.uid() AND m.environment_id IS NULL AND m.role = 'admin'
+    )
+  );
+
+-- Environment-level manager policies (replace legacy 'Staff' policies)
+-- Products
+DROP POLICY IF EXISTS "Staff can modify products" ON products;
+CREATE POLICY "Managers can modify products" ON products
+  FOR ALL USING (
+    EXISTS (
+      SELECT 1 FROM memberships m
+      WHERE m.environment_id = products.environment_id
+        AND m.user_id = auth.uid()
+        AND m.role = 'store_manager'
+    )
+  );
+
+-- Locations
+DROP POLICY IF EXISTS "Staff can modify locations" ON locations;
+CREATE POLICY "Managers can modify locations" ON locations
+  FOR ALL USING (
+    EXISTS (
+      SELECT 1 FROM memberships m
+      WHERE m.environment_id = locations.environment_id
+        AND m.user_id = auth.uid()
+        AND m.role = 'store_manager'
+    )
+  );
+
+-- Product status history
+DROP POLICY IF EXISTS "Staff can create product status history" ON product_status_history;
+CREATE POLICY "Managers can create product status history" ON product_status_history
+  FOR INSERT WITH CHECK (
+    EXISTS (
+      SELECT 1 FROM products p
+      JOIN memberships m ON m.environment_id = p.environment_id
+      WHERE p.id = product_status_history.product_id
+        AND m.user_id = auth.uid()
+        AND m.role = 'store_manager'
+    )
+  );
+
+-- Product comments
+DROP POLICY IF EXISTS "Staff can update any comment" ON product_comments;
+CREATE POLICY "Managers can update any comment" ON product_comments
+  FOR UPDATE USING (
+    EXISTS (
+      SELECT 1 FROM products p
+      JOIN memberships m ON m.environment_id = p.environment_id
+      WHERE p.id = product_comments.product_id
+        AND m.user_id = auth.uid()
+        AND m.role = 'store_manager'
+    )
+  );
+
+DROP POLICY IF EXISTS "Staff can delete any comment" ON product_comments;
+CREATE POLICY "Managers can delete any comment" ON product_comments
+  FOR DELETE USING (
+    EXISTS (
+      SELECT 1 FROM products p
+      JOIN memberships m ON m.environment_id = p.environment_id
+      WHERE p.id = product_comments.product_id
+        AND m.user_id = auth.uid()
+        AND m.role = 'store_manager'
+    )
+  );
+
+-- Product images
+DROP POLICY IF EXISTS "Staff can create product images" ON product_images;
+CREATE POLICY "Managers can create product images" ON product_images
+  FOR INSERT WITH CHECK (
+    EXISTS (
+      SELECT 1 FROM products p
+      JOIN memberships m ON m.environment_id = p.environment_id
+      WHERE p.id = product_images.product_id
+        AND m.user_id = auth.uid()
+        AND m.role = 'store_manager'
+    )
+  );
+
+DROP POLICY IF EXISTS "Staff can delete any image" ON product_images;
+CREATE POLICY "Managers can delete any image" ON product_images
+  FOR DELETE USING (
+    EXISTS (
+      SELECT 1 FROM products p
+      JOIN memberships m ON m.environment_id = p.environment_id
+      WHERE p.id = product_images.product_id
+        AND m.user_id = auth.uid()
+        AND m.role = 'store_manager'
+    )
+  );
+
+-- Sales
+DROP POLICY IF EXISTS "Staff can create sales records" ON sales;
+CREATE POLICY "Managers can create sales records" ON sales
+  FOR INSERT WITH CHECK (
+    EXISTS (
+      SELECT 1 FROM products p
+      JOIN memberships m ON m.environment_id = p.environment_id
+      WHERE p.id = sales.product_id
+        AND m.user_id = auth.uid()
+        AND m.role = 'store_manager'
+    )
+  );
+
+DROP POLICY IF EXISTS "Staff can update sales records" ON sales;
+CREATE POLICY "Managers can update sales records" ON sales
+  FOR UPDATE USING (
+    EXISTS (
+      SELECT 1 FROM products p
+      JOIN memberships m ON m.environment_id = p.environment_id
+      WHERE p.id = sales.product_id
+        AND m.user_id = auth.uid()
+        AND m.role = 'store_manager'
+    )
+  );
+
+DROP POLICY IF EXISTS "Staff can delete sales records" ON sales;
+CREATE POLICY "Managers can delete sales records" ON sales
+  FOR DELETE USING (
+    EXISTS (
+      SELECT 1 FROM products p
+      JOIN memberships m ON m.environment_id = p.environment_id
+      WHERE p.id = sales.product_id
+        AND m.user_id = auth.uid()
+        AND m.role = 'store_manager'
+    )
+  );
+
+-- Environment invites
+DROP POLICY IF EXISTS "Staff can create environment invites" ON environment_invites;
+CREATE POLICY "Managers can create environment invites" ON environment_invites
+  FOR INSERT WITH CHECK (
+    EXISTS (
+      SELECT 1 FROM memberships m
+      WHERE m.environment_id = environment_invites.environment_id
+        AND m.user_id = auth.uid()
+        AND m.role = 'store_manager'
+    )
+  );
+
+DROP POLICY IF EXISTS "Staff can update environment invites" ON environment_invites;
+CREATE POLICY "Managers can update environment invites" ON environment_invites
+  FOR UPDATE USING (
+    EXISTS (
+      SELECT 1 FROM memberships m
+      WHERE m.environment_id = environment_invites.environment_id
+        AND m.user_id = auth.uid()
+        AND m.role = 'store_manager'
+    )
+  );
+
+DROP POLICY IF EXISTS "Staff can delete environment invites" ON environment_invites;
+CREATE POLICY "Managers can delete environment invites" ON environment_invites
+  FOR DELETE USING (
+    EXISTS (
+      SELECT 1 FROM memberships m
+      WHERE m.environment_id = environment_invites.environment_id
+        AND m.user_id = auth.uid()
+        AND m.role = 'store_manager'
+    )
+  );
+
+-- 4) Drop old enum type
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM pg_type WHERE typname = 'role_old') THEN
+    EXECUTE 'DROP TYPE role_old';
+  END IF;
+END $$;
+
+COMMIT;
+


### PR DESCRIPTION
Consolidate all user roles to 'admin' and 'store_manager' to optimize and clarify the codebase.

---
<a href="https://cursor.com/background-agent?bcId=bc-2e87a601-1554-48a1-b1f6-63f0b9ea36bd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-2e87a601-1554-48a1-b1f6-63f0b9ea36bd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>


    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Consolidated all roles to two values: admin and store_manager. This simplifies RBAC across the app and database, and tightens permission checks and policies.

- **Refactors**
  - Replaced legacy roles (grady_admin, grady_staff, reseller_manager, reseller_staff) with admin and store_manager in types, schemas, rbac utils, pages, components, and scripts.
  - Standardized permission checks to ['store_manager', 'admin'] for product management, member invites, and deletions.
  - Simplified admin UI labels/badges and isAdmin logic.
  - Updated docs and script outputs to the new roles.

- **Migration**
  - Run supabase/migrations/009_consolidate_roles.sql (updates enum, migrates data, adds constraints, and rewrites RLS policies). 007/008 included for policy/schema sync.
  - Existing roles are auto-mapped: grady_admin/grady_staff → admin; others → store_manager.
  - Only admin can have a system-wide (NULL environment_id) membership.
  - Recreate/verify a system admin with scripts/create-admin-user.js or scripts/verify-admin-setup.js if needed.

<!-- End of auto-generated description by cubic. -->

